### PR TITLE
[feat/#2] 3대3 -> 2대2로 변경 , 소켓 연결 실패나 매칭 실패 시 UI 복구 및 사용자 알림

### DIFF
--- a/src/api/Meeting/WebRandom.ts
+++ b/src/api/Meeting/WebRandom.ts
@@ -44,7 +44,6 @@ const sendMatchingRequest = async (): Promise<{ matchingId: number; userList: an
   }
 
   try {
-    console.log("🛠 매칭 참가 요청 실행 중...");
     stompClient.publish({
       destination: "/app/matching/join",
       headers: { Authorization: `Bearer ${token}` },
@@ -54,7 +53,6 @@ const sendMatchingRequest = async (): Promise<{ matchingId: number; userList: an
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
   let response = await getRandomNow();
-  console.log("response", response);
   let retryCount = 0;
     while (!response?.data.matchingId && retryCount < 3) {
       //console.log(" 매칭 ID를 찾을 수 없음, 재시도 중...");
@@ -118,12 +116,12 @@ export const cancelMatching = () => {
 export const startMatchingProcess = async ( setRandomNowData : (data: any) => void) => {
   await connectWebSocketRandom();
   track('[접속]미팅_랜덤_실시간소켓');
+  
   // 매칭 참가 요청 후 matchingId 가져오기
   const matchingdata = await sendMatchingRequest();
-  if (matchingdata) {
-    // matchingId를 알게 되면 구독 시작
-    setRandomNowData(matchingdata);
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    subscribeToMatching(matchingdata.matchingId , setRandomNowData);
-  }
+  if (!matchingdata) throw new Error("매칭 ID 없음");
+
+  setRandomNowData(matchingdata);
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  subscribeToMatching(matchingdata.matchingId, setRandomNowData);
 };

--- a/src/components/MeetingRandom/JoinButton/JoinRandomMeetingButton.tsx
+++ b/src/components/MeetingRandom/JoinButton/JoinRandomMeetingButton.tsx
@@ -8,7 +8,7 @@ interface JoinRandomMeetingButtonProps {
 const JoinRandomMeetingButton: React.FC<JoinRandomMeetingButtonProps> = ({ isRandomLoading, onClick }) => {
   return (
     <S.ButtonLayout>
-      <S.WaitPeople>{isRandomLoading && '다른 참여자를 기다리는 중 (예상 시간 : 5분)'}</S.WaitPeople>
+      <S.WaitPeople>{isRandomLoading && '다른 참여자를 기다리는 중 (예상 시간 : 1분)'}</S.WaitPeople>
       <S.Button $isRandomLoading={isRandomLoading} onClick={onClick}>
         {!isRandomLoading && <S.RandomJoinIcon />}
         <S.RandomJoinText>{isRandomLoading ? '매칭 취소하기' : '티켓 1개로 랜덤미팅 참여하기'}</S.RandomJoinText>

--- a/src/components/MeetingRandom/MakeTeamBox/MakeTeamBox.tsx
+++ b/src/components/MeetingRandom/MakeTeamBox/MakeTeamBox.tsx
@@ -23,8 +23,8 @@ const MakeTeamBox: React.FC<MakeTeamBoxProps> = ({ isRandomLoading, randomNowDat
   const femaleUsers = randomNowData?.userList.filter(user => user.gender === 'FEMALE');
   const maleUsers = randomNowData?.userList.filter(user => user.gender === 'MALE');
 
-  const femaleTeam = [...(femaleUsers || []), ...Array(3 - (femaleUsers?.length || 0)).fill(null)].slice(0, 3);
-  const maleTeam = [...(maleUsers || []), ...Array(3 - (maleUsers?.length || 0)).fill(null)].slice(0, 3);
+  const femaleTeam = [...(femaleUsers || []), ...Array(3 - (femaleUsers?.length || 0)).fill(null)].slice(0, 2);
+  const maleTeam = [...(maleUsers || []), ...Array(3 - (maleUsers?.length || 0)).fill(null)].slice(0, 2);
 
   return (
     <S.MakeTeamLayout>

--- a/src/components/MeetingRandom/MakeTeamBox/MakeTeamBox.tsx
+++ b/src/components/MeetingRandom/MakeTeamBox/MakeTeamBox.tsx
@@ -33,7 +33,7 @@ const MakeTeamBox: React.FC<MakeTeamBoxProps> = ({ isRandomLoading, randomNowDat
          <S.Line2 $isRandomLoading={!isRandomLoading}>랜덤 미팅은 1인 신청으로 빠르게 참여!</S.Line2>
       </S.explainComponent>
       <S.GirlComponent>{isRandomLoading && '여자'}</S.GirlComponent>
-      <S.TeamRow>
+      <S.TeamRow $isRandomLoading={!isRandomLoading}>
         {femaleTeam.map((user, index) => (
           <S.FirstPerson key={`female-${index}`}>
             {isRandomLoading? 
@@ -44,7 +44,7 @@ const MakeTeamBox: React.FC<MakeTeamBoxProps> = ({ isRandomLoading, randomNowDat
       </S.TeamRow>
       {isRandomLoading ? <S.LoadingAfter /> :<S.LoadingBefore /> }
       <S.BoyComponent>{isRandomLoading && '남자'}</S.BoyComponent>
-      <S.TeamRow>
+      <S.TeamRow $isRandomLoading={!isRandomLoading}>
         {maleTeam.map((user, index) => (
             <S.FourthPerson key={`male-${index}`}>
               {isRandomLoading? 

--- a/src/components/MeetingRandom/MakeTeamBox/Styles.ts
+++ b/src/components/MeetingRandom/MakeTeamBox/Styles.ts
@@ -41,6 +41,7 @@ export const GirlComponent = styled.div`
   font-size: 15px;
   color: #000000;
   margin-bottom: 2%;
+  margin-left: 13%;
   font-weight: bold;
   align-self: flex-start;
 `;
@@ -49,13 +50,15 @@ export const TeamRow = styled.div`
   display: flex;
   height: 55%;
   width: 100%;
-  justify-content: space-between; 
+  align-items: center;
+  justify-content: center;
 `;
 
 export const BoyComponent = styled.div`
   font-size: 15px;
   color: #000000;
   margin-bottom: 2%;
+  margin-left: 13%;
   font-weight: bold;
   align-self: flex-start;
 `;
@@ -63,8 +66,8 @@ export const BoyComponent = styled.div`
 export const FirstPerson = styled.div`
   font-size: 40px;
   background-color: #F2F2F2;
-  height: 100%; 
-  flex: 1; 
+  width: 35%;
+  height: 90%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/MeetingRandom/MakeTeamBox/Styles.ts
+++ b/src/components/MeetingRandom/MakeTeamBox/Styles.ts
@@ -44,11 +44,12 @@ export const GirlComponent = styled.div`
   margin-left: 13%;
   font-weight: bold;
   align-self: flex-start;
+
 `;
 
-export const TeamRow = styled.div`
+export const TeamRow = styled.div<{ $isRandomLoading: boolean }>`
   display: flex;
-  height: 55%;
+  height: ${({ $isRandomLoading }) => ($isRandomLoading ? '45%' : '100%')}; 
   width: 100%;
   align-items: center;
   justify-content: center;
@@ -96,12 +97,12 @@ export const LoadingBefore = styled(I.RandomBefore)`
   margin-top: 2.5%;
   padding: 2% 0 2% 0;
   width: 25%;
-  height: 25%;
+  height: 20%;
 `;
 
 export const LoadingAfter = styled(I.RandomAfter)`
   margin-top: 2.5%;
   padding: 2% 0 2% 0;
   width: 25%;
-  height: 25%;
+  height: 20%;
 `;

--- a/src/components/MeetingRandom/MeetingRandomMain.tsx
+++ b/src/components/MeetingRandom/MeetingRandomMain.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import MakeTeamBox from './MakeTeamBox/MakeTeamBox';
 import Help from './Help/Help';
 import JoinRandomMeetingButton from './JoinButton/JoinRandomMeetingButton';
@@ -16,6 +16,7 @@ const MeetingRandomMain: React.FC = () => {
   const [ticket, setTicket] = useState<number | null>(null);
   const [randomNowData, setRandomNowData] = useState<RandomTeamType | null>(null);
   const navigate = useNavigate();
+  const wasCanceledRef = useRef(false);
   
   useEffect(() => {
     track('[접속]미팅_랜덤(회원)');
@@ -46,6 +47,7 @@ const MeetingRandomMain: React.FC = () => {
 
   const handleConfirm = async () => {
     setIsModalOpen(false);
+    wasCanceledRef.current = false;
     setIsRandomLoading(true);
     track('[클릭]미팅_랜덤_참여모달_참여');
     //실시간 상태 구독
@@ -54,15 +56,17 @@ const MeetingRandomMain: React.FC = () => {
       navigate('/mypage');
     }
     try {
-      await startMatchingProcess(setRandomNowData);
+      await startMatchingProcess(setRandomNowData, wasCanceledRef);
     } catch (error) {
-      alert('매칭에 실패했어요 ㅜㅜ. 다시 시도해주세요.');
+      if (!wasCanceledRef.current) {
+        alert('매칭에 실패했어요 ㅜㅜ. 다시 시도해주세요.');
+      }
       setIsRandomLoading(false);
       setRandomNowData(null);
-    }
-  };
+    }}
 
   const handleCancel = () => {
+    wasCanceledRef.current = true;
     cancelMatching(); // 서버에 취소 요청
     setIsRandomLoading(false); // 로딩 상태 해제
     setRandomNowData(null);

--- a/src/components/MeetingRandom/MeetingRandomMain.tsx
+++ b/src/components/MeetingRandom/MeetingRandomMain.tsx
@@ -68,8 +68,7 @@ const MeetingRandomMain: React.FC = () => {
     <>
       <MakeTeamBox isRandomLoading={isRandomLoading} randomNowData={randomNowData}/>
       <Help isRandomLoading={!isRandomLoading} onClick={handleHelpClick} />
-      <TicketCount $isRandomLoading={isRandomLoading}>남은 티켓 : 무제한!</TicketCount>
-      {/*<TicketCount $isRandomLoading={isRandomLoading}>남은 티켓 : {ticket}개</TicketCount>*/}
+      <TicketCount $isRandomLoading={isRandomLoading}>남은 티켓 : {ticket}개</TicketCount>
       <JoinRandomMeetingButton isRandomLoading={isRandomLoading} onClick={isRandomLoading ? handleCancel : handleJoinClick}/>
       {isModalOpen && <Modal onClose={handleCloseModal} onConfirm={handleConfirm} ticket={ticket}/>}
     </>

--- a/src/components/MeetingRandom/MeetingRandomMain.tsx
+++ b/src/components/MeetingRandom/MeetingRandomMain.tsx
@@ -44,16 +44,21 @@ const MeetingRandomMain: React.FC = () => {
     track('[클릭]미팅_랜덤_참여모달_취소');
   };
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     setIsModalOpen(false);
     setIsRandomLoading(true);
     track('[클릭]미팅_랜덤_참여모달_참여');
     //실시간 상태 구독
-    startMatchingProcess(setRandomNowData);
-    console.log('startMatchingProcess 실행', randomNowData);
     if (ticket !== null && ticket <= 0) {
       alert('티켓 수가 부족합니다');
       navigate('/mypage');
+    }
+    try {
+      await startMatchingProcess(setRandomNowData);
+    } catch (error) {
+      alert('매칭에 실패했어요 ㅜㅜ. 다시 시도해주세요.');
+      setIsRandomLoading(false);
+      setRandomNowData(null);
     }
   };
 

--- a/src/components/MeetingRandom/Modal/Modal.tsx
+++ b/src/components/MeetingRandom/Modal/Modal.tsx
@@ -17,12 +17,11 @@ const Modal: React.FC<ModalProps> = ({ onClose, onConfirm, ticket }) => {
       <S.ModalContent>
         <S.ModalTitle>랜덤 미팅 안내사항</S.ModalTitle>
         <S.ModalText>
-          랜덤 미팅은 3대3으로 누가 들어올지 모르는<br />
+          랜덤 미팅은 2대2로 누가 들어올지 모르는<br />
           다양하고 재밌는 만남을 위해 진행되고 있어요.<br />
-          3대3이 완성되면 <S.HighlightText>바로 채팅이 열리니</S.HighlightText> 참고해주세요!
+          2대2가 완성되면 <S.HighlightText>바로 채팅이 열리니</S.HighlightText> 참고해주세요!
         </S.ModalText>
-        <S.TicketCount>남은 티켓 : 무제한!</S.TicketCount>
-        {/*<S.TicketCount>남은 티켓 : {ticket}개</S.TicketCount>*/}
+        <S.TicketCount>남은 티켓 : {ticket}개</S.TicketCount>
         <S.ButtonBox>
           <S.CancelButton onClick={onClose}>취소</S.CancelButton>
           <S.ConfirmButton onClick={onConfirm}>참여하기</S.ConfirmButton>

--- a/src/components/Non-member/Meeting/MakeTeamBox/MakeTeamBox.tsx
+++ b/src/components/Non-member/Meeting/MakeTeamBox/MakeTeamBox.tsx
@@ -13,13 +13,11 @@ const MakeTeamBox: React.FC = () => {
       <S.TeamRow>
         <S.FirstPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.FirstPerson>
         <S.SecondPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.SecondPerson>
-        <S.ThirdPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.ThirdPerson>
       </S.TeamRow>
       <S.LoadingBefore />
       <S.TeamRow>
         <S.FourthPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.FourthPerson>
         <S.FifthPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.FifthPerson>
-        <S.SixthPerson><img src={getImageByEmoji(getRandomEmoji())}/></S.SixthPerson>
       </S.TeamRow>
     </S.MakeTeamLayout>
   );


### PR DESCRIPTION
## 🏁 요약
- 3대3 -> 2대2로 변경
- 소켓 연결 실패나 매칭 실패 시 UI 복구 및 사용자 알림
- 관련 이슈 #268 

<br>


## ✨ 주요 변경점
- 2대2에서 3대3으로 변경 
- 매칭 실패/소켓 연결 실패 시 error 처리( try catch문 사용 ) 
- useref로 취소상태 보내줘서 취소되면 에러 팝업 안되게 설정 
- 사용자에게 alert로 실패 이유 안내
- 소켓 연결 실패시 다시 로딩 전 페이지로 이동 

<br>


## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/aee8d881-b039-40e5-a2e1-61c1660d573d" width="300">

